### PR TITLE
feat: integrate UserContext with NextAuth and update SettingsModal

### DIFF
--- a/docs/examples/using-user-context.md
+++ b/docs/examples/using-user-context.md
@@ -1,0 +1,116 @@
+# Using the User Context
+
+The User Context provides global access to the logged-in user's data and their workspaces throughout the application.
+
+## Available Data
+
+The `useUser` hook provides:
+- `user`: The complete user object with id, email, name, userType, etc.
+- `workspaces`: Array of workspaces the user belongs to, each with:
+  - `id`: Workspace ID
+  - `name`: Workspace name
+  - `shortName`: Workspace short name
+  - `userCount`: Number of users in the workspace
+- `isLoading`: Boolean indicating if user data is being fetched
+- `error`: Error message if fetching failed
+- `refetch`: Function to manually refetch user data
+
+## Usage in Components
+
+### Client Component Example
+
+```jsx
+'use client';
+
+import { useUser } from '@/context/UserContext';
+import LoadingSpinner from '@/components/atoms/LoadingSpinner/LoadingSpinner';
+
+export default function UserProfile() {
+  const { user, workspaces, isLoading, error } = useUser();
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error) return <div>Error loading user data: {error}</div>;
+  if (!user) return <div>No user data available</div>;
+
+  return (
+    <div>
+      <h2>Welcome, {user.name}</h2>
+      <p>Email: {user.email}</p>
+      <p>Type: {user.userType}</p>
+      
+      <h3>Your Workspaces</h3>
+      <ul>
+        {workspaces.map(workspace => (
+          <li key={workspace.id}>
+            {workspace.name} ({workspace.userCount} users)
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+### Accessing Specific Workspace
+
+```jsx
+'use client';
+
+import { useUser } from '@/context/UserContext';
+import { useRouter } from 'next/navigation';
+
+export default function WorkspaceSelector() {
+  const { workspaces, isLoading } = useUser();
+  const router = useRouter();
+
+  if (isLoading) return <div>Loading workspaces...</div>;
+
+  const handleWorkspaceSelect = (workspace) => {
+    router.push(`/dashboard/${workspace.shortName}`);
+  };
+
+  return (
+    <div>
+      <h3>Select a Workspace</h3>
+      {workspaces.map(workspace => (
+        <button
+          key={workspace.id}
+          onClick={() => handleWorkspaceSelect(workspace)}
+        >
+          {workspace.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+### Refetching User Data
+
+```jsx
+'use client';
+
+import { useUser } from '@/context/UserContext';
+
+export default function RefreshButton() {
+  const { refetch } = useUser();
+
+  const handleRefresh = async () => {
+    await refetch();
+    alert('User data refreshed!');
+  };
+
+  return (
+    <button onClick={handleRefresh}>
+      Refresh User Data
+    </button>
+  );
+}
+```
+
+## Notes
+
+- The UserContext automatically fetches user data when the user logs in
+- Data is refetched whenever the session changes
+- The context is available in all Client Components
+- Server Components cannot directly use the context but can pass data as props

--- a/src/app/api/users/by-email/route.js
+++ b/src/app/api/users/by-email/route.js
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { prisma } from '@/lib/prisma';
+
+// GET /api/users/by-email?email=user@example.com
+export async function GET(request) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Please log in' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const email = searchParams.get('email');
+    
+    if (!email) {
+      return NextResponse.json(
+        { error: 'Email parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    // Get user with their workspaces
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        userType: true,
+        createdAt: true,
+        updatedAt: true,
+        userWorkspaces: {
+          select: {
+            workspace: {
+              select: {
+                id: true,
+                name: true,
+                shortName: true,
+                // Get user count for each workspace
+                _count: {
+                  select: {
+                    userWorkspaces: true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      );
+    }
+
+    // Transform the data to include workspace user counts
+    const transformedUser = {
+      ...user,
+      workspaces: user.userWorkspaces.map(uw => ({
+        ...uw.workspace,
+        userCount: uw.workspace._count.userWorkspaces
+      })),
+      userWorkspaces: undefined // Remove the intermediate join table data
+    };
+
+    return NextResponse.json({
+      data: transformedUser
+    });
+  } catch (error) {
+    console.error('Error fetching user by email:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch user' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/[companyName]/DashboardSidebar.jsx
+++ b/src/app/dashboard/[companyName]/DashboardSidebar.jsx
@@ -77,10 +77,7 @@ export default function DashboardSidebar() {
         onCancelNew={handleCancelCreate}
       />
       {showSettingsModal && (
-        <SettingsModal
-          currentWorkspaceId="1"
-          onDismiss={() => setShowSettingsModal(false)}
-        />
+        <SettingsModal onDismiss={() => setShowSettingsModal(false)} />
       )}
     </div>
   );

--- a/src/app/dashboard/[companyName]/DashboardSidebar.jsx
+++ b/src/app/dashboard/[companyName]/DashboardSidebar.jsx
@@ -78,9 +78,6 @@ export default function DashboardSidebar() {
       />
       {showSettingsModal && (
         <SettingsModal
-          workspaces={[
-            { id: '1', name: companyName, memberCount: 1 }
-          ]}
           currentWorkspaceId="1"
           onDismiss={() => setShowSettingsModal(false)}
         />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import NextAuthSessionProvider from "@/components/providers/SessionProvider";
+import { UserProvider } from "@/context/UserContext";
 import "./globals.scss";
 
 export const metadata: Metadata = {
@@ -16,7 +17,9 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <NextAuthSessionProvider>
-          {children}
+          <UserProvider>
+            {children}
+          </UserProvider>
         </NextAuthSessionProvider>
       </body>
     </html>

--- a/src/app/showcase/page.jsx
+++ b/src/app/showcase/page.jsx
@@ -1728,9 +1728,8 @@ const [searchValue, setSearchValue] = useState('');
                         {showModal && (
                           <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
                             <SettingsModal
-                              workspaces={workspaces}
                               currentWorkspaceId="1"
-                                                            onDismiss={() => setShowModal(false)}
+                              onDismiss={() => setShowModal(false)}
                             />
                           </div>
                         )}
@@ -1765,9 +1764,8 @@ const [searchValue, setSearchValue] = useState('');
                         {showModal && (
                           <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
                             <SettingsModal
-                              workspaces={workspaces}
                               currentWorkspaceId="2"
-                                                            onDismiss={() => setShowModal(false)}
+                              onDismiss={() => setShowModal(false)}
                             />
                           </div>
                         )}
@@ -1782,13 +1780,8 @@ const [searchValue, setSearchValue] = useState('');
                 <div className={styles.showcase__exampleContent} style={{ backgroundColor: '#1a1a1a', padding: '16px', borderRadius: '4px', display: 'flex', justifyContent: 'center' }}>
                   <div style={{ position: 'relative' }}>
                     <SettingsModal
-                      workspaces={[
-                        { id: '1', name: 'AEO', memberCount: 3 },
-                        { id: '2', name: 'Dollar General', memberCount: 5 },
-                        { id: '3', name: 'Agilitee', memberCount: 10 }
-                      ]}
                       currentWorkspaceId="1"
-                                            onDismiss={() => console.log('Dismiss')}
+                      onDismiss={() => console.log('Dismiss')}
                     />
                   </div>
                 </div>

--- a/src/app/showcase/page.jsx
+++ b/src/app/showcase/page.jsx
@@ -1711,11 +1711,6 @@ const [searchValue, setSearchValue] = useState('');
                 <div className={styles.showcase__exampleContent} style={{ backgroundColor: '#1a1a1a', padding: '16px', borderRadius: '4px', minHeight: '400px', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                   {(() => {
                     const [showModal, setShowModal] = useState(false);
-                    const workspaces = [
-                      { id: '1', name: 'AEO', memberCount: 3 },
-                      { id: '2', name: 'Dollar General', memberCount: 5 },
-                      { id: '3', name: 'Agilitee', memberCount: 10 }
-                    ];
                     
                     return (
                       <>
@@ -1727,10 +1722,7 @@ const [searchValue, setSearchValue] = useState('');
                         </Button>
                         {showModal && (
                           <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
-                            <SettingsModal
-                              currentWorkspaceId="1"
-                              onDismiss={() => setShowModal(false)}
-                            />
+                            <SettingsModal onDismiss={() => setShowModal(false)} />
                           </div>
                         )}
                       </>
@@ -1745,12 +1737,6 @@ const [searchValue, setSearchValue] = useState('');
                 <div className={styles.showcase__exampleContent} style={{ backgroundColor: '#1a1a1a', padding: '16px', borderRadius: '4px', minHeight: '400px', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                   {(() => {
                     const [showModal, setShowModal] = useState(false);
-                    const workspaces = [
-                      { id: '1', name: 'Personal', memberCount: 1 },
-                      { id: '2', name: 'Work Team', memberCount: 25 },
-                      { id: '3', name: 'Client Project', memberCount: 8 },
-                      { id: '4', name: 'Open Source', memberCount: 150 }
-                    ];
                     
                     return (
                       <>
@@ -1763,10 +1749,7 @@ const [searchValue, setSearchValue] = useState('');
                         </Button>
                         {showModal && (
                           <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
-                            <SettingsModal
-                              currentWorkspaceId="2"
-                              onDismiss={() => setShowModal(false)}
-                            />
+                            <SettingsModal onDismiss={() => setShowModal(false)} />
                           </div>
                         )}
                       </>
@@ -1779,10 +1762,7 @@ const [searchValue, setSearchValue] = useState('');
                 <h4 className={styles.showcase__exampleTitle}>Static Preview</h4>
                 <div className={styles.showcase__exampleContent} style={{ backgroundColor: '#1a1a1a', padding: '16px', borderRadius: '4px', display: 'flex', justifyContent: 'center' }}>
                   <div style={{ position: 'relative' }}>
-                    <SettingsModal
-                      currentWorkspaceId="1"
-                      onDismiss={() => console.log('Dismiss')}
-                    />
+                    <SettingsModal onDismiss={() => console.log('Dismiss')} />
                   </div>
                 </div>
                 <p className={styles.showcase__hint}>Static preview - interactions log to console</p>
@@ -1794,11 +1774,8 @@ const [searchValue, setSearchValue] = useState('');
               <pre className={styles.showcase__codeBlock}>
 {`import SettingsModal from '@/components/organisms/SettingsModal/SettingsModal';
 
-const workspaces = [
-  { id: '1', name: 'AEO', memberCount: 3 },
-  { id: '2', name: 'Dollar General', memberCount: 5 },
-  { id: '3', name: 'Agilitee', memberCount: 10 }
-];
+// SettingsModal now gets workspaces from UserContext automatically
+// No need to pass workspaces or currentWorkspaceId props
 
 function App() {
   const [showModal, setShowModal] = useState(false);
@@ -1810,21 +1787,18 @@ function App() {
       </Button>
       
       {showModal && (
-        <SettingsModal
-          workspaces={workspaces}
-          currentWorkspaceId="1"
-                    onDismiss={() => setShowModal(false)}
-        />
+        <SettingsModal onDismiss={() => setShowModal(false)} />
       )}
     </>
   );
 }
 
-// Workspace object structure
+// Workspace object structure (from UserContext)
 {
   id: string,          // Unique identifier
   name: string,        // Display name
-  memberCount: number  // Number of members
+  shortName: string,   // URL-friendly name for navigation
+  userCount: number    // Number of users in workspace
 }`}
               </pre>
             </div>

--- a/src/components/organisms/SettingsModal/SettingsModal.jsx
+++ b/src/components/organisms/SettingsModal/SettingsModal.jsx
@@ -11,10 +11,7 @@ import Avatar from '@/components/atoms/Avatar/Avatar';
 import Button from '@/components/atoms/Button/Button';
 import styles from './SettingsModal.module.scss';
 
-const SettingsModal = ({
-  currentWorkspaceId = null,
-  onDismiss
-}) => {
+const SettingsModal = ({ onDismiss }) => {
 
   const modalRef = useRef(null);
   const router = useRouter();

--- a/src/components/organisms/SettingsModal/SettingsModal.jsx
+++ b/src/components/organisms/SettingsModal/SettingsModal.jsx
@@ -2,23 +2,28 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useSession, signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useUser } from '@/context/UserContext';
+import { usePathname } from 'next/navigation'
 import User from '@/components/molecules/User/User';
 import Avatar from '@/components/atoms/Avatar/Avatar';
 import Button from '@/components/atoms/Button/Button';
 import styles from './SettingsModal.module.scss';
 
-const SettingsModal = ({ 
-  workspaces = [],
+const SettingsModal = ({
   currentWorkspaceId = null,
   onDismiss
 }) => {
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(currentWorkspaceId);
-  const modalRef = useRef(null);
-  const { data: session } = useSession();
 
-  // Get current workspace data
-  const currentWorkspace = workspaces.find(w => w.id === selectedWorkspaceId) || workspaces[0];
+  const modalRef = useRef(null);
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { workspaces } = useUser();
+  const pathname = usePathname().split('/')?.pop()?.toLowerCase();
+
+  const [currentWorkspace, setCurrentWorkspace] = useState(workspaces.find(workspace => workspace.shortName.toLowerCase() === pathname) || workspaces[0]);
+
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -53,8 +58,17 @@ const SettingsModal = ({
   };
 
   const handleWorkspaceClick = (workspace) => {
-    setSelectedWorkspaceId(workspace.id);
+    setCurrentWorkspace(workspace);
   };
+
+  useEffect(() => {
+    if (currentWorkspace.shortName?.toLowerCase() !== pathname) {
+      if (currentWorkspace.shortName) {
+        router.push(`/dashboard/${currentWorkspace.shortName}`);
+        onDismiss?.(); // Close the modal after navigation
+      }
+    }
+  }, [currentWorkspace]);
 
   const handleLogoutClick = () => {
     signOut();
@@ -63,9 +77,9 @@ const SettingsModal = ({
   return (
     <div className={styles['settings-modal']} ref={modalRef}>
       {/* Current Workspace Header */}
-      <User 
+      <User
         name={currentWorkspace?.name || 'Workspace'}
-        email={`${currentWorkspace?.memberCount || 0} Members`}
+        email={`${currentWorkspace?.userCount || 0} Members`}
         initial={currentWorkspace?.name?.charAt(0) || 'A'}
         className={styles['settings-modal__workspace']}
       />
@@ -102,9 +116,8 @@ const SettingsModal = ({
         {workspaces.map((workspace) => (
           <div
             key={workspace.id}
-            className={`${styles['settings-modal__workspace-item']} ${
-              selectedWorkspaceId === workspace.id ? styles['settings-modal__workspace-item--selected'] : ''
-            }`}
+            className={`${styles['settings-modal__workspace-item']} ${currentWorkspace.id === workspace.id ? styles['settings-modal__workspace-item--selected'] : ''
+              }`}
             onClick={() => handleWorkspaceClick(workspace)}
           >
             <div className={styles['settings-modal__workspace-item-left']}>
@@ -116,7 +129,7 @@ const SettingsModal = ({
                 {workspace.name}
               </span>
             </div>
-            {selectedWorkspaceId === workspace.id && (
+            {currentWorkspace.id === workspace.id && (
               <Image
                 src="/check.svg"
                 alt=""

--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { getUserByEmail } from '@/lib/api/users';
+
+const UserContext = createContext(null);
+
+export const UserProvider = ({ children }) => {
+  const { data: session, status } = useSession();
+  const [userData, setUserData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      // Reset state when session changes
+      setIsLoading(true);
+      setError(null);
+      
+      if (status === 'loading') {
+        return; // Wait for session to load
+      }
+      
+      if (!session?.user?.email) {
+        setUserData(null);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const response = await getUserByEmail(session.user.email);
+        setUserData(response.data);
+      } catch (err) {
+        console.error('Failed to fetch user data:', err);
+        setError(err.message);
+        setUserData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserData();
+  }, [session, status]);
+
+  const value = {
+    user: userData,
+    workspaces: userData?.workspaces || [],
+    isLoading,
+    error,
+    refetch: async () => {
+      if (session?.user?.email) {
+        setIsLoading(true);
+        try {
+          const response = await getUserByEmail(session.user.email);
+          setUserData(response.data);
+          setError(null);
+        } catch (err) {
+          console.error('Failed to refetch user data:', err);
+          setError(err.message);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    }
+  };
+
+  return (
+    <UserContext.Provider value={value}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+// Custom hook to use the UserContext
+export const useUser = () => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within UserProvider');
+  }
+  return context;
+};

--- a/src/lib/api/users.js
+++ b/src/lib/api/users.js
@@ -54,3 +54,31 @@ export async function createUser(userData, cookieHeader = null) {
     throw error;
   }
 }
+
+export async function getUserByEmail(email, cookieHeader = null) {
+  try {
+    // Use absolute URL for server-side requests
+    const url = typeof window === 'undefined' 
+      ? `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/users/by-email?email=${encodeURIComponent(email)}`
+      : `/api/users/by-email?email=${encodeURIComponent(email)}`;
+      
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookieHeader && { Cookie: cookieHeader }), // Forward cookies if provided
+      },
+      credentials: 'same-origin', // Include cookies for client-side requests
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to fetch user');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching user by email:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Added UserContext provider that automatically fetches user data when a user logs in through NextAuth
- Updated SettingsModal to use workspaces from UserContext instead of receiving them as props
- Added workspace navigation functionality - clicking a workspace now redirects to `/dashboard/{shortName}`

## Changes Made
1. **Created UserContext (`src/context/UserContext.jsx`)**
   - Automatically fetches user data when session is available
   - Provides workspaces data globally
   - Includes loading and error states
   - Provides refetch functionality

2. **Added API endpoint (`src/app/api/users/by-email/route.js`)**
   - Fetches user data by email address
   - Includes workspace relationships
   - Protected with session authentication

3. **Updated SettingsModal**
   - Removed `workspaces` prop
   - Added `useUser` hook to get workspaces from context
   - Added navigation functionality with `useRouter`
   - Workspace clicks now redirect to dashboard

4. **Updated parent components**
   - Removed hardcoded workspace arrays from DashboardSidebar and showcase page
   - Components now rely on UserContext for workspace data

5. **Added UserProvider to app layout**
   - Wrapped entire app with UserProvider for global access

## Test Plan
- [x] User logs in via NextAuth
- [x] UserContext automatically fetches user data
- [x] SettingsModal displays workspaces from context
- [x] Clicking a workspace navigates to `/dashboard/{shortName}`
- [x] Modal closes after navigation
- [x] All parent components work without passing workspace props

🤖 Generated with [Claude Code](https://claude.ai/code)