### PR TITLE
feat: add double-click rename functionality for pages

### DIFF
--- a/src/components/molecules/ListItem/ListItem.jsx
+++ b/src/components/molecules/ListItem/ListItem.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import styles from './ListItem.module.scss';
 
@@ -8,16 +9,62 @@ const ListItem = ({
   icon = '/document.svg',
   selected = false,
   onClick,
+  onRename,
   className = ''
 }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(text);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleDoubleClick = (e) => {
+    e.stopPropagation();
+    if (onRename) {
+      setIsEditing(true);
+      setEditValue(text);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (editValue.trim() && editValue !== text) {
+      onRename?.(editValue.trim());
+    }
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditValue(text);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  const handleInputClick = (e) => {
+    e.stopPropagation();
+  };
+
   return (
     <div 
       className={`${styles['list-item']} ${selected ? styles['list-item--selected'] : ''} ${className}`}
       onClick={onClick}
+      onDoubleClick={handleDoubleClick}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (!isEditing && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           onClick?.();
         }
@@ -33,9 +80,22 @@ const ListItem = ({
             className={styles['list-item__icon-image']}
           />
         </div>
-        <span className={styles['list-item__text']}>
-          {text}
-        </span>
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={handleSubmit}
+            onKeyDown={handleKeyDown}
+            onClick={handleInputClick}
+            className={styles['list-item__input']}
+          />
+        ) : (
+          <span className={styles['list-item__text']}>
+            {text}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/molecules/ListItem/ListItem.module.scss
+++ b/src/components/molecules/ListItem/ListItem.module.scss
@@ -35,6 +35,21 @@
     @include truncate;
   }
   
+  &__input {
+    @include nav-item;
+    background-color: $black-light;
+    color: $white-primary;
+    border: 1px solid $white-secondary;
+    border-radius: 4px;
+    padding: 2px 4px;
+    width: 100%;
+    outline: none;
+    
+    &:focus {
+      border-color: $white-primary;
+    }
+  }
+  
   // Hover state
   &:hover {
     background-color: $black-light-hover;

--- a/src/components/templates/Sidebar/Sidebar.jsx
+++ b/src/components/templates/Sidebar/Sidebar.jsx
@@ -21,7 +21,8 @@ const Sidebar = ({
   onAdminBack,
   isAddingNew = false,
   onCreateNew,
-  onCancelNew
+  onCancelNew,
+  onRenameItem
 }) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -122,6 +123,7 @@ const Sidebar = ({
                       icon="/document.svg"
                       selected={item.id === selectedItemId}
                       onClick={() => handleContextItemClick(item)}
+                      onRename={onRenameItem ? (newName) => onRenameItem(item.id, newName) : undefined}
                     />
                   ))}
                   {isAddingNew ? (


### PR DESCRIPTION
- Update ListItem component to support inline editing on double-click
- Add input styles for rename mode in ListItem.module.scss
- Pass rename handler through Sidebar to ListItem components
- Implement rename functionality in DashboardSidebar using upsertPage API
- Add optimistic UI updates with error handling and rollback

Users can now double-click on page names in the sidebar to rename them. Changes are persisted to the database automatically.