### PR TITLE
feat: Add VariantsModal component from Figma design

### DIFF
--- a/docs/VariantsModal.md
+++ b/docs/VariantsModal.md
@@ -1,0 +1,216 @@
+# VariantsModal Component Documentation
+
+## Overview
+The `VariantsModal` is an organism-level component that displays code variants in a modal dialog with syntax highlighting and action buttons. It was created based on the Figma design reference.
+
+## Figma Reference
+- **URL**: https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Cyke-Web-App?node-id=210-4777&m=dev
+- **Node ID**: 210:4777
+- **Component Name**: VariantsModal
+
+## Import
+```javascript
+import VariantsModal from '@/components/organisms/VariantsModal/VariantsModal';
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isOpen` | `boolean` | `false` | Controls the visibility of the modal |
+| `onClose` | `function` | - | Callback function called when the modal should close |
+| `title` | `string` | `'Clade.md'` | The title displayed in the modal header |
+| `version` | `string` | `'Version 2'` | The version text displayed below the title |
+| `codeContent` | `string` | `''` | Markdown content with code to be displayed |
+| `onSetToMaster` | `function` | - | Callback for "Set to Master" button click |
+| `onCreateExperiment` | `function` | - | Callback for "Create Experiment with Variant" button click |
+
+## Usage Examples
+
+### Basic Usage
+```jsx
+import { useState } from 'react';
+import VariantsModal from '@/components/organisms/VariantsModal/VariantsModal';
+
+function MyComponent() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const codeContent = `
+\`\`\`typescript
+// Standard component template
+@Component({
+  selector: 'app-example',
+  templateUrl: './example.component.html',
+  styleUrls: ['./example.component.scss']
+})
+export class ExampleComponent implements OnInit {
+  // Properties first
+  public data: any[] = [];
+
+  // Constructor
+  constructor(private service: ExampleService) {}
+
+  // Lifecycle hooks
+  ngOnInit() {}
+
+  // Public methods
+  public handleAction() {}
+
+  // Private methods
+  private helperMethod() {}
+}
+\`\`\`
+  `;
+
+  return (
+    <>
+      <button onClick={() => setIsModalOpen(true)}>
+        Open Variants Modal
+      </button>
+
+      <VariantsModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Component.ts"
+        version="Version 3"
+        codeContent={codeContent}
+        onSetToMaster={() => {
+          console.log('Setting to master version');
+          setIsModalOpen(false);
+        }}
+        onCreateExperiment={() => {
+          console.log('Creating experiment with variant');
+          setIsModalOpen(false);
+        }}
+      />
+    </>
+  );
+}
+```
+
+### With Dynamic Content
+```jsx
+import { useState, useEffect } from 'react';
+import VariantsModal from '@/components/organisms/VariantsModal/VariantsModal';
+
+function VariantManager({ variantId }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [variantData, setVariantData] = useState(null);
+
+  useEffect(() => {
+    if (isModalOpen && variantId) {
+      // Fetch variant data from API
+      fetchVariantData(variantId).then(setVariantData);
+    }
+  }, [isModalOpen, variantId]);
+
+  const handleSetToMaster = async () => {
+    try {
+      await updateVariantStatus(variantId, 'master');
+      setIsModalOpen(false);
+      // Show success message
+    } catch (error) {
+      // Handle error
+    }
+  };
+
+  const handleCreateExperiment = async () => {
+    try {
+      await createExperiment(variantId);
+      setIsModalOpen(false);
+      // Navigate to experiment page
+    } catch (error) {
+      // Handle error
+    }
+  };
+
+  return (
+    <VariantsModal
+      isOpen={isModalOpen}
+      onClose={() => setIsModalOpen(false)}
+      title={variantData?.name || 'Loading...'}
+      version={variantData?.version || ''}
+      codeContent={variantData?.code || ''}
+      onSetToMaster={handleSetToMaster}
+      onCreateExperiment={handleCreateExperiment}
+    />
+  );
+}
+```
+
+## Features
+
+### Modal Behavior
+- **Click Outside to Close**: Clicking outside the modal content area will trigger the `onClose` callback
+- **Body Scroll Prevention**: When the modal is open, the body scroll is disabled to prevent background scrolling
+- **Responsive Design**: The modal adapts to different screen sizes with appropriate max-width and height constraints
+
+### Code Display
+- **Syntax Highlighting**: Uses MDXEditor with CodeMirror for syntax highlighting
+- **Read-only Mode**: The code display is read-only to prevent accidental edits
+- **Multiple Language Support**: Supports JavaScript, TypeScript, Python, CSS, SCSS, HTML, JSON, SQL, and more
+- **Custom Scrollbar**: Styled scrollbar for better visual consistency
+
+### Accessibility
+- **ARIA Labels**: Close button has proper aria-label for screen readers
+- **Focus Management**: Buttons have visible focus states
+- **Keyboard Navigation**: All interactive elements are keyboard accessible
+
+## Styling
+
+The component uses CSS Modules with SCSS and follows the BEM methodology. Key style features include:
+
+- Dark theme with colors from the design system
+- Smooth transitions for hover and active states
+- Custom syntax highlighting colors matching the Figma design
+- Responsive breakpoints for mobile and tablet views
+
+### Customization
+
+To customize the modal's appearance, you can:
+
+1. Override CSS variables in your global styles
+2. Pass additional className props (if needed, can be added)
+3. Modify the SCSS file directly for project-specific changes
+
+## Testing
+
+The component includes comprehensive tests covering:
+
+- Rendering with different prop combinations
+- User interactions (clicks, outside clicks)
+- Modal open/close behavior
+- Body scroll prevention
+- Event listener cleanup
+- Accessibility features
+
+Run tests with:
+```bash
+npm test VariantsModal.test.jsx
+```
+
+## Dependencies
+
+- `react` (hooks: useEffect, useRef)
+- `next/image` for the close icon
+- `@mdxeditor/editor` for markdown rendering and syntax highlighting
+- Custom Button component from atoms (currently not used but available)
+
+## Notes
+
+- The component currently uses custom buttons instead of the reusable Button component to match the exact Figma design
+- The MDXEditor is configured for read-only mode since this is for displaying code variants
+- The modal uses a fixed position overlay with a semi-transparent backdrop
+- Consider implementing animation/transition effects for modal open/close (not in current design)
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+1. Add animation for smooth modal entrance/exit
+2. Support for copying code to clipboard
+3. Keyboard shortcut support (ESC to close)
+4. Loading state while fetching variant content
+5. Error state handling for failed content loads
+6. Integration with existing Button component from atoms
+7. Support for theme switching (light/dark mode)

--- a/src/app/showcase/page.jsx
+++ b/src/app/showcase/page.jsx
@@ -19,6 +19,7 @@ import AddWorkspaceModal from '@/components/organisms/AddWorkspaceModal/AddWorks
 import AddUserModal from '@/components/organisms/AddUserModal/AddUserModal';
 import CreateExperimentModal from '@/components/organisms/CreateExperimentModal/CreateExperimentModal';
 import VariantCard from '@/components/organisms/VariantCard/VariantCard';
+import VariantsModal from '@/components/organisms/VariantsModal/VariantsModal';
 import Sidebar from '@/components/templates/Sidebar/Sidebar';
 import UsersTable from '@/components/templates/UsersTable/UsersTable';
 import WorkspacesTable from '@/components/templates/WorkspacesTable/WorkspacesTable';
@@ -29,6 +30,7 @@ import styles from './page.module.scss';
 
 export default function ShowcasePage() {
   const [searchValue, setSearchValue] = useState('');
+  const [isVariantsModalOpen, setIsVariantsModalOpen] = useState(false);
 
   const handleSearch = (value) => {
     console.log('Search submitted:', value);
@@ -2428,6 +2430,110 @@ const handleCreate = (formData) => {
               </pre>
             </div>
           </div>
+
+          {/* VariantsModal Component */}
+          <div className={styles.showcase__component}>
+            <h3 className={styles.showcase__componentTitle}>VariantsModal</h3>
+            <p className={styles.showcase__componentDescription}>
+              A modal component for displaying code variants with syntax highlighting and action buttons.
+            </p>
+            
+            <div className={styles.showcase__demo}>
+              <div className={styles.showcase__example}>
+                <h4 className={styles.showcase__exampleTitle}>Click to Open Modal</h4>
+                <div className={styles.showcase__exampleContent}>
+                  <Button 
+                    variant="primary"
+                    onClick={() => setIsVariantsModalOpen(true)}
+                  >
+                    Open Variants Modal
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.showcase__code}>
+              <h4 className={styles.showcase__codeTitle}>Usage</h4>
+              <pre className={styles.showcase__codeBlock}>
+{`import VariantsModal from '@/components/organisms/VariantsModal/VariantsModal';
+
+// Basic usage
+const [isModalOpen, setIsModalOpen] = useState(false);
+
+const codeContent = \`
+\\\`\\\`\\\`typescript
+@Component({
+  selector: 'app-example',
+  templateUrl: './example.component.html'
+})
+export class ExampleComponent implements OnInit {
+  public data: any[] = [];
+  
+  ngOnInit() {}
+  
+  public handleAction() {}
+}
+\\\`\\\`\\\`
+\`;
+
+<VariantsModal
+  isOpen={isModalOpen}
+  onClose={() => setIsModalOpen(false)}
+  title="Component.ts"
+  version="Version 3"
+  codeContent={codeContent}
+  onSetToMaster={() => {
+    console.log('Setting to master');
+    setIsModalOpen(false);
+  }}
+  onCreateExperiment={() => {
+    console.log('Creating experiment');
+    setIsModalOpen(false);
+  }}
+/>`}
+              </pre>
+            </div>
+          </div>
+
+          {/* VariantsModal Instance */}
+          <VariantsModal
+            isOpen={isVariantsModalOpen}
+            onClose={() => setIsVariantsModalOpen(false)}
+            title="Clade.md"
+            version="Version 2"
+            codeContent={`\`\`\`typescript
+// Standard component template
+@Component({
+  selector: 'app-example',
+  templateUrl: './example.component.html',
+  styleUrls: ['./example.component.scss']
+})
+export class ExampleComponent implements OnInit {
+  // Properties first
+  public data: any[] = [];
+
+  // Constructor
+  constructor(private service: ExampleService) {}
+
+  // Lifecycle hooks
+  ngOnInit() {}
+
+  // Public methods
+  public handleAction() {}
+
+  // Private methods
+  private helperMethod() {}
+}
+\`\`\``}
+            onSetToMaster={() => {
+              alert('Set to Master clicked');
+              setIsVariantsModalOpen(false);
+            }}
+            onCreateExperiment={() => {
+              alert('Create Experiment with Variant clicked');
+              setIsVariantsModalOpen(false);
+            }}
+          />
 
         </section>
 

--- a/src/components/organisms/VariantsModal/VariantsModal.jsx
+++ b/src/components/organisms/VariantsModal/VariantsModal.jsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Image from 'next/image';
+import Button from '@/components/atoms/Button/Button';
+import { MDXEditor, headingsPlugin, codeBlockPlugin, codeMirrorPlugin, CodeMirrorEditor } from '@mdxeditor/editor';
+import '@mdxeditor/editor/style.css';
+import styles from './VariantsModal.module.scss';
+
+const VariantsModal = ({ 
+  isOpen = false,
+  onClose,
+  title = 'Clade.md',
+  version = 'Version 2',
+  codeContent = '',
+  onSetToMaster,
+  onCreateExperiment
+}) => {
+  const modalRef = useRef(null);
+
+  // Handle click outside to close modal
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (modalRef.current && !modalRef.current.contains(event.target)) {
+        onClose?.();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+
+  // Don't render if not open
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles['variants-modal']}>
+      <div className={styles['variants-modal__container']} ref={modalRef}>
+        <div className={styles['variants-modal__content']}>
+          {/* Header */}
+          <div className={styles['variants-modal__header']}>
+            <div className={styles['variants-modal__header-content']}>
+              <h2 className={styles['variants-modal__title']}>{title}</h2>
+              <span className={styles['variants-modal__version']}>{version}</span>
+            </div>
+            <button 
+              className={styles['variants-modal__close']}
+              onClick={onClose}
+              aria-label="Close modal"
+            >
+              <Image 
+                src="/cross.svg"
+                alt=""
+                width={16}
+                height={16}
+              />
+            </button>
+          </div>
+
+          {/* Divider */}
+          <div className={styles['variants-modal__divider']} />
+
+          {/* Code Block */}
+          <div className={styles['variants-modal__code-block']}>
+            <MDXEditor
+              markdown={codeContent}
+              readOnly
+              plugins={[
+                headingsPlugin(),
+                codeBlockPlugin({ 
+                  codeBlockEditorDescriptors: [
+                    { 
+                      priority: -10, 
+                      match: (_) => true, 
+                      Editor: CodeMirrorEditor 
+                    }
+                  ] 
+                }),
+                codeMirrorPlugin({
+                  codeBlockLanguages: {
+                    js: 'JavaScript',
+                    ts: 'TypeScript',
+                    tsx: 'TypeScript React',
+                    jsx: 'JavaScript React',
+                    css: 'CSS',
+                    scss: 'SCSS',
+                    html: 'HTML',
+                    json: 'JSON',
+                    python: 'Python',
+                    sql: 'SQL',
+                    bash: 'Bash',
+                    markdown: 'Markdown'
+                  }
+                })
+              ]}
+            />
+          </div>
+
+          {/* Action Buttons */}
+          <div className={styles['variants-modal__actions']}>
+            <button
+              className={`${styles['variants-modal__button']} ${styles['variants-modal__button--secondary']}`}
+              onClick={onSetToMaster}
+            >
+              Set to Master
+            </button>
+            <button
+              className={`${styles['variants-modal__button']} ${styles['variants-modal__button--primary']}`}
+              onClick={onCreateExperiment}
+            >
+              Create Experiment with Variant
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VariantsModal;

--- a/src/components/organisms/VariantsModal/VariantsModal.module.scss
+++ b/src/components/organisms/VariantsModal/VariantsModal.module.scss
@@ -1,0 +1,262 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
+.variants-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba($black, 0.5);
+  z-index: 1000;
+  padding: 20px;
+
+  &__container {
+    width: 100%;
+    max-width: 742px;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+
+  &__content {
+    background-color: $black-bg-dark;
+    border: 1px solid $black-light;
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__header-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+  }
+
+  &__title {
+    @include heading-2;
+    color: $white-primary;
+    margin: 0;
+  }
+
+  &__version {
+    @include body-medium;
+    @include font-medium;
+    color: $white-secondary;
+    letter-spacing: 0.2px;
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
+  }
+
+  &__divider {
+    height: 1px;
+    background-color: $black-light;
+    width: 100%;
+  }
+
+  &__code-block {
+    background-color: $black-code;
+    border-radius: 8px;
+    padding: 16px;
+    min-height: 400px;
+    overflow: auto;
+    position: relative;
+
+    // Custom scrollbar styling
+    &::-webkit-scrollbar {
+      width: 4px;
+      height: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: $black-hover-light;
+      border-radius: 10px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: lighten($black-hover-light, 10%);
+    }
+
+    // Override MDXEditor styles for read-only mode
+    :global {
+      .mdxeditor {
+        background-color: transparent;
+        font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+        color: $white-primary;
+      }
+
+      .cm-editor {
+        background-color: transparent !important;
+      }
+
+      .cm-content {
+        padding: 0;
+        caret-color: transparent;
+      }
+
+      .cm-line {
+        padding: 0;
+      }
+
+      // Syntax highlighting colors matching Figma design
+      .cm-keyword {
+        color: $code-blue;
+      }
+
+      .cm-string {
+        color: #9bdf68;
+      }
+
+      .cm-comment {
+        color: #958169;
+      }
+
+      .cm-variable {
+        color: $white-primary;
+      }
+
+      .cm-variableName {
+        color: #ecec9e;
+      }
+
+      .cm-typeName {
+        color: #ecec9e;
+      }
+
+      .cm-propertyName {
+        color: $white-primary;
+      }
+
+      .cm-operator {
+        color: #ecba56;
+      }
+
+      .cm-punctuation {
+        color: $white-primary;
+      }
+
+      .cm-bracket {
+        color: $white-primary;
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+    margin-top: auto;
+  }
+
+  &__button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    border-radius: 8px;
+    background-color: transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    @include body-large;
+    @include font-semibold;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+    width: 100%;
+
+    &--secondary {
+      border: 1px solid $white-secondary;
+      color: $white-secondary;
+
+      &:hover {
+        background-color: rgba($white-secondary, 0.1);
+        border-color: lighten($white-secondary, 10%);
+      }
+
+      &:focus-visible {
+        outline: 2px solid $white-secondary;
+        outline-offset: 2px;
+      }
+
+      &:active {
+        transform: scale(0.98);
+      }
+    }
+
+    &--primary {
+      border: 1px solid $code-blue;
+      color: $code-blue;
+
+      &:hover {
+        background-color: rgba($code-blue, 0.1);
+        border-color: lighten($code-blue, 10%);
+      }
+
+      &:focus-visible {
+        outline: 2px solid $code-blue;
+        outline-offset: 2px;
+      }
+
+      &:active {
+        transform: scale(0.98);
+      }
+    }
+  }
+
+  // Responsive adjustments
+  @media (max-width: 768px) {
+    padding: 10px;
+
+    &__container {
+      max-width: 100%;
+    }
+
+    &__code-block {
+      min-height: 300px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    &__code-block {
+      min-height: 200px;
+      padding: 12px;
+    }
+  }
+}

--- a/src/components/organisms/VariantsModal/VariantsModal.test.jsx
+++ b/src/components/organisms/VariantsModal/VariantsModal.test.jsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VariantsModal from './VariantsModal';
+
+// Mock the MDXEditor component since it requires browser environment
+jest.mock('@mdxeditor/editor', () => ({
+  MDXEditor: ({ markdown, readOnly }) => (
+    <div data-testid="mdx-editor" data-readonly={readOnly}>
+      {markdown}
+    </div>
+  ),
+  headingsPlugin: jest.fn(),
+  codeBlockPlugin: jest.fn(),
+  codeMirrorPlugin: jest.fn(),
+  CodeMirrorEditor: jest.fn()
+}));
+
+// Mock Next.js Image component
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props) => {
+    // eslint-disable-next-line jsx-a11y/alt-text
+    return <img {...props} />
+  },
+}));
+
+describe('VariantsModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    title: 'Test Modal',
+    version: 'Version 1',
+    codeContent: '```javascript\nconst test = "hello";\n```',
+    onSetToMaster: jest.fn(),
+    onCreateExperiment: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.style.overflow = 'unset';
+  });
+
+  it('should render when isOpen is true', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    expect(screen.getByText('Version 1')).toBeInTheDocument();
+    expect(screen.getByText('Set to Master')).toBeInTheDocument();
+    expect(screen.getByText('Create Experiment with Variant')).toBeInTheDocument();
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(<VariantsModal {...defaultProps} isOpen={false} />);
+    
+    expect(screen.queryByText('Test Modal')).not.toBeInTheDocument();
+  });
+
+  it('should display code content in MDXEditor', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    const editor = screen.getByTestId('mdx-editor');
+    expect(editor).toHaveTextContent('```javascript\nconst test = "hello";\n```');
+    expect(editor).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('should call onClose when close button is clicked', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    const closeButton = screen.getByLabelText('Close modal');
+    fireEvent.click(closeButton);
+    
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onSetToMaster when Set to Master button is clicked', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    const setToMasterButton = screen.getByText('Set to Master');
+    fireEvent.click(setToMasterButton);
+    
+    expect(defaultProps.onSetToMaster).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onCreateExperiment when Create Experiment button is clicked', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    const createExperimentButton = screen.getByText('Create Experiment with Variant');
+    fireEvent.click(createExperimentButton);
+    
+    expect(defaultProps.onCreateExperiment).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close when clicking outside the modal', async () => {
+    const { container } = render(<VariantsModal {...defaultProps} />);
+    
+    // Click on the backdrop (outside the modal content)
+    const backdrop = container.querySelector('.variants-modal');
+    fireEvent.mouseDown(backdrop);
+    
+    await waitFor(() => {
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not close when clicking inside the modal content', () => {
+    const { container } = render(<VariantsModal {...defaultProps} />);
+    
+    // Click inside the modal content
+    const modalContent = container.querySelector('.variants-modal__content');
+    fireEvent.mouseDown(modalContent);
+    
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+  });
+
+  it('should prevent body scroll when modal is open', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('should restore body scroll when modal is closed', () => {
+    const { rerender } = render(<VariantsModal {...defaultProps} />);
+    
+    expect(document.body.style.overflow).toBe('hidden');
+    
+    rerender(<VariantsModal {...defaultProps} isOpen={false} />);
+    
+    expect(document.body.style.overflow).toBe('unset');
+  });
+
+  it('should use default values when props are not provided', () => {
+    render(
+      <VariantsModal 
+        isOpen={true}
+        onClose={jest.fn()}
+      />
+    );
+    
+    expect(screen.getByText('Clade.md')).toBeInTheDocument();
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+  });
+
+  it('should handle empty code content', () => {
+    render(
+      <VariantsModal 
+        {...defaultProps}
+        codeContent=""
+      />
+    );
+    
+    const editor = screen.getByTestId('mdx-editor');
+    expect(editor).toHaveTextContent('');
+  });
+
+  it('should have proper accessibility attributes', () => {
+    render(<VariantsModal {...defaultProps} />);
+    
+    const closeButton = screen.getByLabelText('Close modal');
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+    
+    const { unmount } = render(<VariantsModal {...defaultProps} />);
+    
+    unmount();
+    
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(document.body.style.overflow).toBe('unset');
+    
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should handle markdown content with multiple code blocks', () => {
+    const multiBlockContent = `
+\`\`\`javascript
+const func1 = () => {};
+\`\`\`
+
+Some text between blocks
+
+\`\`\`typescript
+interface Test {
+  name: string;
+}
+\`\`\`
+    `;
+
+    render(
+      <VariantsModal 
+        {...defaultProps}
+        codeContent={multiBlockContent}
+      />
+    );
+    
+    const editor = screen.getByTestId('mdx-editor');
+    expect(editor).toHaveTextContent(multiBlockContent);
+  });
+
+  it('should properly style buttons based on their variant', () => {
+    const { container } = render(<VariantsModal {...defaultProps} />);
+    
+    const setToMasterButton = screen.getByText('Set to Master').closest('button');
+    const createExperimentButton = screen.getByText('Create Experiment with Variant').closest('button');
+    
+    expect(setToMasterButton).toHaveClass('variants-modal__button--secondary');
+    expect(createExperimentButton).toHaveClass('variants-modal__button--primary');
+  });
+});

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -28,6 +28,10 @@ $code-blue: #74A0C8;  // Code/Blue - Used for Settings modal CTAs
 $code-red: #EB5757;
 $border-color: rgba($white-primary, 0.1);  // Border color for subtle dividers
 
+// Code Block Colors (from VariantsModal design)
+$black-code: #202020;  // Black/Code - Code block background color
+$black-hover-light: #474747;  // Black/Hover Light - Scrollbar and hover states
+
 // Seat Type Colors
 $editor-green: #4e6557;  // Editor seat type background
 $admin-red: #654e4e;     // Admin seat type background


### PR DESCRIPTION
## Description
Implements VariantsModal component based on Figma design.

## Figma Reference
- URL: https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Cyke-Web-App?node-id=210-4777&m=dev
- Node ID: 210:4777
- Component: VariantsModal (organism level)

## Changes
- ✅ Added VariantsModal component structure following Next.js/React best practices
- ✅ Integrated MDXEditor for markdown rendering with syntax highlighting
- ✅ Implemented modal behaviors (click outside to close, body scroll prevention)
- ✅ Created comprehensive test suite with high coverage
- ✅ Added complete documentation with usage examples
- ✅ Added component to showcase page for demonstration
- ✅ Added missing SCSS variables for code block styling

## Component Features
- Modal overlay with semi-transparent backdrop
- Header with title, version, and close button (using /public/cross.svg)
- Code display area with syntax highlighting via MDXEditor
- Two action buttons: 'Set to Master' and 'Create Experiment with Variant'
- Responsive design with mobile/tablet breakpoints
- Accessibility features (ARIA labels, focus states)

## Testing
- [x] Unit tests pass
- [x] Linting passes (only warnings in existing files)
- [x] Build succeeds
- [x] Manual testing completed in showcase page
- [x] Cross-browser compatibility (modern browsers)

## Screenshots
Component matches the Figma design with:
- Dark theme (#252525 background)
- Code block with syntax highlighting
- Action buttons with proper styling
- Modal close on outside click

Closes #79