### PR TITLE
feat: add variants API endpoint

### DIFF
--- a/docs/api/variants.md
+++ b/docs/api/variants.md
@@ -1,0 +1,243 @@
+# Variants API Documentation
+
+## Overview
+The Variants API provides read-only access to CLAUDE.md file variants stored in the database. Each variant represents a different version or configuration of documentation for a specific workspace.
+
+## Base URL
+`/api/variants`
+
+## Authentication
+Currently, no authentication is required. Future versions may require Bearer token authentication.
+
+## Endpoints
+
+### List Variants
+Retrieve a paginated list of variants with optional filtering and sorting.
+
+```
+GET /api/variants
+```
+
+#### Query Parameters
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| page | number | 1 | Page number for pagination |
+| limit | number | 10 | Number of items per page |
+| workspaceId | string | - | Filter variants by workspace ID |
+| search | string | - | Search in content and summary fields |
+| sortBy | string | createdAt | Field to sort by (createdAt, updatedAt) |
+| sortOrder | string | desc | Sort order (asc or desc) |
+
+#### Response
+```json
+{
+  "data": [
+    {
+      "id": "cuid_string",
+      "content": "# Markdown content...",
+      "summary": "Brief description of the variant",
+      "workspaceId": "workspace_cuid",
+      "createdAt": "2025-08-08T21:42:16.598Z",
+      "updatedAt": "2025-08-08T21:42:16.598Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 50,
+    "totalPages": 5
+  }
+}
+```
+
+### Get Single Variant
+Retrieve a specific variant by its ID.
+
+```
+GET /api/variants/:id
+```
+
+#### URL Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | string | Yes | The variant ID (CUID format) |
+
+#### Response
+```json
+{
+  "id": "cuid_string",
+  "content": "# Markdown content...",
+  "summary": "Brief description of the variant",
+  "workspaceId": "workspace_cuid",
+  "createdAt": "2025-08-08T21:42:16.598Z",
+  "updatedAt": "2025-08-08T21:42:16.598Z"
+}
+```
+
+## Error Responses
+
+### 404 Not Found
+Returned when a variant with the specified ID doesn't exist.
+
+```json
+{
+  "error": "Variant not found"
+}
+```
+
+### 500 Internal Server Error
+Returned when a server error occurs.
+
+```json
+{
+  "error": "Failed to fetch variants"
+}
+```
+
+## Usage Examples
+
+### JavaScript/TypeScript
+
+#### Using the API Client Functions
+
+```javascript
+import { 
+  getVariants, 
+  getVariantById, 
+  getVariantsByWorkspace,
+  getLatestVariantForWorkspace 
+} from '@/lib/api/variants';
+
+// Fetch all variants with pagination
+const response = await getVariants({ 
+  page: 1, 
+  limit: 20 
+});
+console.log(response.data); // Array of variants
+console.log(response.meta); // Pagination metadata
+
+// Fetch a single variant by ID
+const variant = await getVariantById('cme3cq592001d8owemmgcko13');
+console.log(variant.content);
+
+// Fetch variants for a specific workspace
+const workspaceVariants = await getVariantsByWorkspace('workspace_id', {
+  limit: 50,
+  sortBy: 'createdAt',
+  sortOrder: 'desc'
+});
+
+// Get the most recent variant for a workspace
+const latestVariant = await getLatestVariantForWorkspace('workspace_id');
+if (latestVariant) {
+  console.log('Latest variant:', latestVariant.summary);
+}
+```
+
+#### Direct Fetch API
+
+```javascript
+// Fetch variants with filters
+const response = await fetch('/api/variants?workspaceId=ws_123&limit=5');
+const data = await response.json();
+
+// Fetch single variant
+const variantResponse = await fetch('/api/variants/variant_id');
+const variant = await variantResponse.json();
+```
+
+### React Component Example
+
+```jsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getVariantsByWorkspace } from '@/lib/api/variants';
+
+export default function VariantsList({ workspaceId }) {
+  const [variants, setVariants] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchVariants = async () => {
+      try {
+        setLoading(true);
+        const response = await getVariantsByWorkspace(workspaceId);
+        setVariants(response.data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchVariants();
+  }, [workspaceId]);
+
+  if (loading) return <div>Loading variants...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div>
+      {variants.map(variant => (
+        <div key={variant.id}>
+          <h3>{variant.summary}</h3>
+          <pre>{variant.content}</pre>
+          <small>Created: {new Date(variant.createdAt).toLocaleDateString()}</small>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+### cURL Examples
+
+```bash
+# List all variants
+curl -X GET "http://localhost:3000/api/variants"
+
+# List variants with pagination
+curl -X GET "http://localhost:3000/api/variants?page=2&limit=20"
+
+# Filter by workspace
+curl -X GET "http://localhost:3000/api/variants?workspaceId=cme3cq4q600028owe428y4wfz"
+
+# Search in content and summary
+curl -X GET "http://localhost:3000/api/variants?search=security"
+
+# Get single variant
+curl -X GET "http://localhost:3000/api/variants/cme3cq592001d8owemmgcko13"
+
+# Combined filters
+curl -X GET "http://localhost:3000/api/variants?workspaceId=ws_123&search=API&sortBy=updatedAt&sortOrder=asc"
+```
+
+## Data Model
+
+### Variant Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Unique identifier (CUID) |
+| content | string | The full markdown content of the variant |
+| summary | string | Brief description of the variant's purpose |
+| workspaceId | string | Associated workspace identifier |
+| createdAt | datetime | ISO 8601 timestamp of creation |
+| updatedAt | datetime | ISO 8601 timestamp of last update |
+
+## Rate Limiting
+
+Currently, no rate limiting is implemented. Future versions may include:
+- 100 requests per minute per IP
+- 1000 requests per hour per user
+
+## Changelog
+
+### Version 1.0.0 (2025-08-08)
+- Initial release with GET endpoints
+- Pagination support
+- Workspace filtering
+- Search functionality
+- Sorting options

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:seed": "node prisma/seed.js",
+    "prisma:studio": "prisma studio"
   },
   "dependencies": {
     "@mdxeditor/editor": "^3.40.0",

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -132,6 +132,8 @@ async function main() {
   // Delete existing data
   await prisma.userWorkspace.deleteMany();
   await prisma.page.deleteMany();
+  await prisma.variant.deleteMany();
+  await prisma.suggestion.deleteMany();
   await prisma.user.deleteMany();
   await prisma.workspace.deleteMany();
   
@@ -175,6 +177,146 @@ async function main() {
       data: page
     });
     console.log(`Created page: ${page.name}`);
+  }
+  
+  // Create sample variants for each workspace
+  const variants = [
+    {
+      content: `# Project Guidelines for American Eagle
+
+## Code Style
+- Use functional components with React hooks
+- Follow atomic design principles  
+- Use SCSS modules with BEM methodology
+- Implement proper error handling
+
+## Best Practices
+- Keep components small and reusable
+- Use proper TypeScript types
+- Write comprehensive tests
+- Document all API endpoints
+
+## Development Standards
+- Follow ESLint rules
+- Use Prettier for formatting
+- Commit messages should follow conventional commits`,
+      summary: 'Initial project guidelines with code style and best practices for AE',
+      workspaceId: createdWorkspaces['Americal Eagle']
+    },
+    {
+      content: `# Development Workflow for American Eagle
+
+## Git Workflow
+1. Create feature branches from main
+2. Write descriptive commit messages
+3. Create pull requests for review
+4. Run tests before merging
+
+## Code Review Process
+- Check for code quality
+- Verify test coverage
+- Ensure documentation is updated
+- Validate performance impact
+
+## Deployment Process
+- Stage changes in development
+- Test in staging environment
+- Deploy to production with approval`,
+      summary: 'Development workflow including Git practices and deployment process for AE',
+      workspaceId: createdWorkspaces['Americal Eagle']
+    },
+    {
+      content: `# API Documentation for Dollar General
+
+## RESTful Endpoints
+- GET /api/products - List all products
+- GET /api/products/:id - Get single product
+- POST /api/products - Create new product
+- PUT /api/products/:id - Update product
+- DELETE /api/products/:id - Delete product
+
+## Authentication
+All endpoints require Bearer token authentication
+
+## Rate Limiting
+- 100 requests per minute per IP
+- 1000 requests per hour per user`,
+      summary: 'API documentation with RESTful endpoints and authentication for DG',
+      workspaceId: createdWorkspaces['Dollar General']
+    },
+    {
+      content: `# Testing Strategy for Dollar General
+
+## Unit Testing
+- Test individual components
+- Mock external dependencies
+- Achieve 80% code coverage
+
+## Integration Testing
+- Test API endpoints
+- Verify database operations
+- Test user workflows
+
+## E2E Testing
+- Test critical user journeys
+- Verify cross-browser compatibility
+- Mobile responsiveness testing`,
+      summary: 'Comprehensive testing strategy covering unit, integration, and E2E tests for DG',
+      workspaceId: createdWorkspaces['Dollar General']
+    },
+    {
+      content: `# Performance Optimization for Agilitee
+
+## Frontend Optimization
+- Use React.memo for expensive components
+- Implement lazy loading
+- Optimize bundle size
+- Use proper caching strategies
+
+## Backend Optimization
+- Implement database indexing
+- Use query optimization
+- Add response caching
+- Monitor API performance
+
+## CDN Strategy
+- Static assets on CDN
+- Image optimization
+- Compression enabled`,
+      summary: 'Performance optimization guidelines for frontend and backend at Agilitee',
+      workspaceId: createdWorkspaces['Agilitee']
+    },
+    {
+      content: `# Security Best Practices for Agilitee
+
+## Input Validation
+- Sanitize all user inputs
+- Validate data types and formats
+- Implement rate limiting
+- Use parameterized queries
+
+## Authentication & Authorization
+- Use secure token storage
+- Implement proper session management
+- Apply principle of least privilege
+- Regular security audits
+
+## Data Protection
+- Encrypt sensitive data
+- HTTPS everywhere
+- Regular backups`,
+      summary: 'Security best practices for input validation and data protection at Agilitee',
+      workspaceId: createdWorkspaces['Agilitee']
+    }
+  ];
+
+  for (const variant of variants) {
+    if (variant.workspaceId) {
+      await prisma.variant.create({
+        data: variant
+      });
+      console.log(`Created variant: ${variant.summary}`);
+    }
   }
   
   console.log('Seeding completed!');

--- a/src/app/api/variants/[id]/route.js
+++ b/src/app/api/variants/[id]/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+// GET /api/variants/:id
+export async function GET(request, { params }) {
+  try {
+    const { id } = params;
+    
+    const variant = await prisma.variant.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        content: true,
+        summary: true,
+        workspaceId: true,
+        createdAt: true,
+        updatedAt: true
+      }
+    });
+
+    if (!variant) {
+      return NextResponse.json(
+        { error: 'Variant not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(variant);
+  } catch (error) {
+    console.error(`Error fetching variant ${params.id}:`, error);
+    return NextResponse.json(
+      { error: 'Failed to fetch variant' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/variants/route.js
+++ b/src/app/api/variants/route.js
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+// GET /api/variants
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = parseInt(searchParams.get('page') || '1');
+    const limit = parseInt(searchParams.get('limit') || '10');
+    const workspaceId = searchParams.get('workspaceId');
+    const search = searchParams.get('search') || '';
+    const sortBy = searchParams.get('sortBy') || 'createdAt';
+    const sortOrder = searchParams.get('sortOrder') || 'desc';
+
+    // Build where clause
+    const where = {};
+    
+    // Filter by workspaceId if provided
+    if (workspaceId) {
+      where.workspaceId = workspaceId;
+    }
+    
+    // Search in content and summary
+    if (search) {
+      where.OR = [
+        { content: { contains: search, mode: 'insensitive' } },
+        { summary: { contains: search, mode: 'insensitive' } }
+      ];
+    }
+
+    // Execute query with pagination
+    const [variants, total] = await prisma.$transaction([
+      prisma.variant.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { [sortBy]: sortOrder },
+        select: {
+          id: true,
+          content: true,
+          summary: true,
+          workspaceId: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      }),
+      prisma.variant.count({ where })
+    ]);
+
+    return NextResponse.json({
+      data: variants,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit)
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching variants:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch variants' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/api/variants.js
+++ b/src/lib/api/variants.js
@@ -1,0 +1,94 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
+
+/**
+ * Fetch all variants with optional filters
+ * @param {Object} params - Query parameters
+ * @param {number} params.page - Page number
+ * @param {number} params.limit - Items per page
+ * @param {string} params.workspaceId - Filter by workspace ID
+ * @param {string} params.search - Search term for content/summary
+ * @param {string} params.sortBy - Sort field
+ * @param {string} params.sortOrder - Sort order (asc/desc)
+ * @returns {Promise<{data: Array, meta: Object}>}
+ */
+export async function getVariants(params = {}) {
+  try {
+    const queryString = new URLSearchParams(params).toString();
+    const response = await fetch(`${API_BASE}/api/variants${queryString ? `?${queryString}` : ''}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to fetch variants');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching variants:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a single variant by ID
+ * @param {string} id - The variant ID
+ * @returns {Promise<Object>}
+ */
+export async function getVariantById(id) {
+  try {
+    const response = await fetch(`${API_BASE}/api/variants/${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Variant not found');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(`Error fetching variant ${id}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch all variants for a specific workspace
+ * @param {string} workspaceId - The workspace ID
+ * @param {Object} options - Additional query options
+ * @returns {Promise<{data: Array, meta: Object}>}
+ */
+export async function getVariantsByWorkspace(workspaceId, options = {}) {
+  return getVariants({
+    workspaceId,
+    ...options
+  });
+}
+
+/**
+ * Fetch the most recent variant for a workspace
+ * @param {string} workspaceId - The workspace ID
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestVariantForWorkspace(workspaceId) {
+  try {
+    const response = await getVariants({
+      workspaceId,
+      limit: 1,
+      sortBy: 'createdAt',
+      sortOrder: 'desc'
+    });
+    
+    return response.data[0] || null;
+  } catch (error) {
+    console.error(`Error fetching latest variant for workspace ${workspaceId}:`, error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Description
Created a new API endpoint for reading variants data from the database and updated the variants page to use real data instead of mock data.

## Changes
✅ **API Implementation**
- Added GET `/api/variants` endpoint with pagination, filtering, and search
- Added GET `/api/variants/:id` endpoint for single variant retrieval
- Implemented proper error handling and status codes
- Created API client functions in `lib/api/variants.js`

✅ **Frontend Integration**
- Updated variants page to fetch data from API
- Added loading and error states
- Transform API data to match component structure
- Removed hardcoded mock data

✅ **Database Setup**
- Updated seed file to include sample variants data
- Added 6 sample variants across 3 workspaces
- Added Prisma helper scripts to package.json

✅ **Documentation**
- Created comprehensive API documentation in `docs/api/variants.md`
- Includes usage examples, cURL commands, and TypeScript/JavaScript examples

## Testing
- [x] API endpoints tested with cURL
- [x] Variants page loads data from API
- [x] Search functionality works
- [x] Pagination works correctly
- [x] Error handling tested

## API Features
- **Pagination**: `page` and `limit` parameters
- **Filtering**: Filter by `workspaceId`
- **Search**: Search in content and summary fields
- **Sorting**: Sort by `createdAt` or `updatedAt`

## Sample API Calls
```bash
# Get all variants
GET /api/variants

# Get variants for a workspace
GET /api/variants?workspaceId=workspace_id

# Search variants
GET /api/variants?search=security

# Get single variant
GET /api/variants/:id
```

## Screenshots
The variants page now displays real data from the database instead of mock data.

## Related Issues
Closes the need for hardcoded mock data in the variants page.