### PR TITLE
feat: Add insufficient data state to ExperimentsModal

### DIFF
--- a/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
+++ b/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
@@ -81,7 +81,7 @@ const ExperimentsModal = ({
     }
 
     const p = successes / total;
-    const z = 1.96; // 95% CI
+    const z = 1.645; // 90% CI
     const se = Math.sqrt((p * (1 - p)) / total);
 
     // Calculate bounds
@@ -174,6 +174,10 @@ const ExperimentsModal = ({
   };
 
   const impactDescription = calculateImpactDescription();
+  
+  // Calculate total PRs across both variants
+  const totalPRs = (pageStatsData.totalValue || 0) + (variantStatsData.totalValue || 0);
+  const hasEnoughData = totalPRs >= 200;
 
   // Handle click outside to close modal
   useEffect(() => {
@@ -239,57 +243,74 @@ const ExperimentsModal = ({
           {/* Divider */}
           <div className={styles['experiments-modal__divider']} />
 
-          {/* Results Section */}
-          <ChartSection
-            title="Results"
-            className={styles['experiments-modal__section']}
-          >
-            <p className={styles['experiments-modal__section-description']}>
-              {(() => {
-                const parts = resultsData.description.split(/(\d+(?:\.\d+)?%)/g);
-                return parts.map((part, index) => {
-                  if (part.match(/\d+(?:\.\d+)?%/)) {
-                    return <span key={index} className={styles['experiments-modal__highlight']}>{part}</span>;
-                  }
-                  return part;
-                });
-              })()}
-            </p>
-          </ChartSection>
+          {/* Conditional content based on data availability */}
+          {hasEnoughData ? (
+            <>
+              {/* Results Section */}
+              <ChartSection
+                title="Results"
+                className={styles['experiments-modal__section']}
+              >
+                <p className={styles['experiments-modal__section-description']}>
+                  {(() => {
+                    const parts = resultsData.description.split(/(\d+(?:\.\d+)?%)/g);
+                    return parts.map((part, index) => {
+                      if (part.match(/\d+(?:\.\d+)?%/)) {
+                        return <span key={index} className={styles['experiments-modal__highlight']}>{part}</span>;
+                      }
+                      return part;
+                    });
+                  })()}
+                </p>
+              </ChartSection>
 
-          {/* Stats for Nerds Section */}
-          <ChartSection
-            title="Stats for Nerds"
-            className={styles['experiments-modal__section']}
-          >
-            <div className={styles['experiments-modal__stats']}>
-              <p className={styles['experiments-modal__stat']}>
-                A two-proportion Z-Test resulted in a one-tailed p-value of{' '}
-                <span className={styles['experiments-modal__stat-value--green']}>
-                  {statsData.pValue}
-                </span>
-              </p>
-              <p className={styles['experiments-modal__stat']}>
-                95% Confidence Interval for Master:{' '}
-                <span className={styles['experiments-modal__stat-value']}>
-                  {statsData.masterConfidenceInterval}
-                </span>
-              </p>
-              <p className={styles['experiments-modal__stat']}>
-                95% Confidence Interval for Variant 3:{' '}
-                <span className={styles['experiments-modal__stat-value']}>
-                  {statsData.variantConfidenceInterval}
-                </span>
-              </p>
-            </div>
-          </ChartSection>
+              {/* Stats for Nerds Section */}
+              <ChartSection
+                title="Stats for Nerds"
+                className={styles['experiments-modal__section']}
+              >
+                <div className={styles['experiments-modal__stats']}>
+                  <p className={styles['experiments-modal__stat']}>
+                    A two-proportion Z-Test resulted in a one-tailed p-value of{' '}
+                    <span className={styles['experiments-modal__stat-value--green']}>
+                      {statsData.pValue}
+                    </span>
+                  </p>
+                  <p className={styles['experiments-modal__stat']}>
+                    90% Confidence Interval for Master:{' '}
+                    <span className={styles['experiments-modal__stat-value']}>
+                      {statsData.masterConfidenceInterval}
+                    </span>
+                  </p>
+                  <p className={styles['experiments-modal__stat']}>
+                    90% Confidence Interval for Variant 3:{' '}
+                    <span className={styles['experiments-modal__stat-value']}>
+                      {statsData.variantConfidenceInterval}
+                    </span>
+                  </p>
+                </div>
+              </ChartSection>
 
-          {/* Potential Impact Section */}
-          <ChartSection
-            title="Potential Impact"
-            description={impactDescription}
-            className={styles['experiments-modal__section']}
-          />
+              {/* Potential Impact Section */}
+              <ChartSection
+                title="Potential Impact"
+                description={impactDescription}
+                className={styles['experiments-modal__section']}
+              />
+            </>
+          ) : (
+            <>
+              {/* Insufficient Data Message */}
+              <ChartSection
+                title="Results"
+                className={styles['experiments-modal__section']}
+              >
+                <p className={styles['experiments-modal__section-description']}>
+                  Ckye requires 200 total MRs before posting results. Currently this test has reviewed {totalPRs} MRs.
+                </p>
+              </ChartSection>
+            </>
+          )}
 
           {/* Charts Section with Variant Cards */}
           <div className={styles['experiments-modal__charts']}>


### PR DESCRIPTION
## Summary
- Updated confidence intervals from 95% to 90% for statistical calculations
- Added conditional rendering to show different UI states based on data availability
- Implemented minimum threshold of 200 total PRs for showing full statistics

## Changes
### Statistical Updates
- Changed z-score from 1.96 to 1.645 for 90% confidence interval
- Updated all confidence interval labels from "95%" to "90%"

### New Insufficient Data State
- Added check for total PR count (page + variant PRs)
- When total PRs < 200:
  - Shows simplified "Results" section with informative message
  - Displays current PR count progress (e.g., "Currently this test has reviewed 150 MRs")
  - Hides Stats for Nerds and Potential Impact sections
  - Still shows variant cards with current statistics
- When total PRs ≥ 200:
  - Shows full analysis with all sections
  - Displays calculated p-values, confidence intervals, and impact descriptions

## Test Plan
- [x] Verify modal shows insufficient data state when total PRs < 200
- [x] Verify modal shows full statistics when total PRs ≥ 200  
- [x] Confirm 90% confidence intervals are calculated correctly
- [x] Test with various PR counts to ensure threshold works properly
- [x] Verify "End Experiment" button still only shows for active experiments

## Screenshots
The modal now adapts based on data availability, providing a cleaner UX when insufficient data is available for statistical significance.

🤖 Generated with [Claude Code](https://claude.ai/code)