### PR TITLE
fix: Hide Settings and Invite Members from left navigation

### DIFF
--- a/src/components/templates/Sidebar/Sidebar.jsx
+++ b/src/components/templates/Sidebar/Sidebar.jsx
@@ -69,15 +69,16 @@ const Sidebar = ({
     }
   };
 
-  const handleSettingsClick = () => {
-    console.log('Settings');
-    // TODO: Navigate to settings page
-  };
+  // Temporarily commented out - features not yet implemented (CKYE-2)
+  // const handleSettingsClick = () => {
+  //   console.log('Settings');
+  //   // TODO: Navigate to settings page
+  // };
 
-  const handleInviteMembersClick = () => {
-    console.log('Invite Members');
-    // TODO: Navigate to invite members page
-  };
+  // const handleInviteMembersClick = () => {
+  //   console.log('Invite Members');
+  //   // TODO: Navigate to invite members page
+  // };
 
   const handleAdminClick = () => {
     router.push('/admin/workspaces');
@@ -191,6 +192,7 @@ const Sidebar = ({
                       router.push(`/dashboard/${accountName.toLowerCase()}?view=experiments`);
                     }}
                   />
+                  {/* Temporarily hidden - features not yet implemented (CKYE-2)
                   <ListItem
                     text="Settings"
                     icon="/settings.svg"
@@ -203,6 +205,7 @@ const Sidebar = ({
                     selected={false}
                     onClick={handleInviteMembersClick}
                   />
+                  */}
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
Temporarily hide Settings and Invite Members links from the left navigation since these features are not yet implemented.

## Changes
- Commented out Settings menu item in Sidebar component
- Commented out Invite Members menu item in Sidebar component  
- Commented out unused handler functions to avoid dead code

## Testing
- [x] Linting passed
- [x] Production build successful
- [x] Navigation still functions correctly
- [x] No broken links in UI

## Related Issues
Closes #107
Fixes [CKYE-2](https://ckye.atlassian.net/browse/CKYE-2)

🤖 Generated with [Claude Code](https://claude.ai/code)