### PR TITLE
feat: Add automated PR status checks via GitHub Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,50 @@
+# GitHub Actions Workflows
+
+## check-pr-statuses.yml
+
+This workflow automatically checks PR statuses and updates statistics every 4 hours.
+
+### Schedule
+- Runs every 4 hours (0:00, 4:00, 8:00, 12:00, 16:00, 20:00 UTC)
+- Can be manually triggered from Actions tab
+
+### Required Secrets
+
+You need to add these secrets in your GitHub repository:
+1. Go to Settings → Secrets and variables → Actions
+2. Add the following secrets:
+
+#### ANTHROPIC_API_KEY (Required)
+Your Claude API key for running Claude Code commands.
+- Get it from: https://console.anthropic.com/account/keys
+
+#### DATABASE_URL (Required)
+The connection string for your database where PR statistics are stored.
+- Format: `postgresql://user:password@host:port/database`
+
+#### GITHUB_TOKEN (Automatic)
+This is automatically provided by GitHub Actions, no setup needed.
+
+### Manual Trigger
+You can manually run the workflow from the Actions tab:
+1. Go to Actions tab in your repository
+2. Select "Check PR Statuses" workflow
+3. Click "Run workflow"
+4. Optionally enter a different Page ID
+5. Click "Run workflow" button
+
+### Monitoring
+- Check the Actions tab for run history
+- Failed runs will create an issue automatically
+- Each run creates a summary in the workflow run page
+
+### Customization
+- To change schedule: Edit the cron expression in the workflow file
+- To check different page IDs: Use manual trigger with custom input
+- To disable issue creation on failure: Comment out the "Notify on Failure" step
+
+### Troubleshooting
+1. **Workflow not running**: Check if Actions are enabled in repository settings
+2. **Authentication errors**: Verify ANTHROPIC_API_KEY secret is set correctly
+3. **Database errors**: Check DATABASE_URL connection string
+4. **Permission errors**: Ensure workflow has correct permissions in the yaml file

--- a/.github/workflows/check-pr-statuses.yml
+++ b/.github/workflows/check-pr-statuses.yml
@@ -1,0 +1,90 @@
+name: Check PR Statuses
+
+on:
+  schedule:
+    # Run every 4 hours
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+    # Allow manual trigger for testing
+    inputs:
+      pageId:
+        description: 'Page/Variant ID to check (optional)'
+        required: false
+        default: 'cme78g7a700018ovg8p0ijuv0'
+
+jobs:
+  check-pr-statuses:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic/claude-code
+      
+      - name: Configure Claude Code
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Set up Claude Code configuration
+          export CLAUDE_API_KEY="${ANTHROPIC_API_KEY}"
+      
+      - name: Run PR Status Check
+        id: check_status
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PAGE_ID: ${{ github.event.inputs.pageId || 'cme78g7a700018ovg8p0ijuv0' }}
+        run: |
+          echo "Checking PR statuses for page ID: ${PAGE_ID}"
+          
+          # Run the check-pr-statuses command
+          # Note: This requires Claude Code CLI to be configured to run command files
+          claude code << 'EOF'
+          Execute the check-pr-statuses command for page ID: ${PAGE_ID}
+          
+          Steps:
+          1. Fetch all PRs for page ID: ${PAGE_ID}
+          2. Check each PR status via GitHub API
+          3. Count merged PRs and commits
+          4. Update statistics in database
+          5. Delete processed PRs from tracking
+          EOF
+      
+      - name: Create Summary
+        if: always()
+        run: |
+          echo "## PR Status Check Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Run Time**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Page ID**: ${{ env.PAGE_ID }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the logs above for detailed statistics." >> $GITHUB_STEP_SUMMARY
+      
+      - name: Notify on Failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Optional: Create an issue on failure
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Automated] PR Status Check Failed - ${new Date().toISOString()}`,
+              body: `The automated PR status check failed. Please check the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+              labels: ['automated', 'bug']
+            });
+            console.log(`Created issue #${issue.data.number}`);


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically check PR statuses every 4 hours
- Workflow updates statistics for merged PRs in the database
- Supports manual trigger with custom page ID input

## Features
- **Automated Schedule**: Runs every 4 hours (cron: `0 */4 * * *`)
- **Manual Trigger**: Can be run manually from Actions tab with custom page ID
- **Error Handling**: Creates GitHub issue automatically if check fails
- **Documentation**: Includes setup guide for required secrets

## Setup Required
After merging, you'll need to add these secrets in Settings → Secrets → Actions:
1. `ANTHROPIC_API_KEY` - Your Claude API key
2. `DATABASE_URL` - Database connection string

## Files Added
- `.github/workflows/check-pr-statuses.yml` - The workflow definition
- `.github/workflows/README.md` - Setup and troubleshooting guide

## Testing
- Manual trigger available immediately after merge
- Scheduled runs will start automatically every 4 hours
- Check Actions tab for run history and results

🤖 Generated with [Claude Code](https://claude.ai/code)