### PR TITLE
fix: remove console.error from page-statistics API route

### DIFF
--- a/src/app/api/page-statistics/route.js
+++ b/src/app/api/page-statistics/route.js
@@ -74,8 +74,7 @@ export async function POST(request) {
       type: isVariant ? 'variant' : 'page'
     });
 
-  } catch (error) {
-    console.error('Error updating page statistics:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to update page statistics' },
       { status: 500 }


### PR DESCRIPTION
## Summary
- Removed console.error statement from page-statistics API route
- Fixed unused error variable warning by using catch without parameter

## Changes
- Cleaned up error handling in `/api/page-statistics/route.js`
- Improved code quality by removing unnecessary console logging

## Test Plan
- [x] Lint passes without warnings for this file
- [x] Build completes successfully
- [x] API endpoint continues to function correctly