### PR TITLE
[CKYE-4] Reorder the Stats for Nerds card in experiments modal

### DIFF
--- a/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
+++ b/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
@@ -333,37 +333,6 @@ const ExperimentsModal = ({
                 )}
               </ChartSection>
 
-              {/* Stats for Nerds Section */}
-              <ChartSection
-                title="Stats for Nerds"
-                className={styles['experiments-modal__section']}
-              >
-                <div className={styles['experiments-modal__stats']}>
-                  <p className={styles['experiments-modal__stat']}>
-                    A two-proportion Z-Test resulted in a one-tailed p-value of{' '}
-                    <span className={
-                      statsData.pValue !== 'N/A' && !isNaN(statsData.pValue) && parseFloat(statsData.pValue) >= 0.10
-                        ? styles['experiments-modal__stat-value--red']
-                        : styles['experiments-modal__stat-value--green']
-                    }>
-                      {statsData.pValue}
-                    </span>
-                  </p>
-                  <p className={styles['experiments-modal__stat']}>
-                    90% Confidence Interval for Master:{' '}
-                    <span className={styles['experiments-modal__stat-value']}>
-                      {statsData.masterConfidenceInterval}
-                    </span>
-                  </p>
-                  <p className={styles['experiments-modal__stat']}>
-                    90% Confidence Interval for Variant:{' '}
-                    <span className={styles['experiments-modal__stat-value']}>
-                      {statsData.variantConfidenceInterval}
-                    </span>
-                  </p>
-                </div>
-              </ChartSection>
-
               {/* Potential Impact Section */}
               <ChartSection
                 title="Potential Impact"
@@ -423,6 +392,39 @@ const ExperimentsModal = ({
               className={styles['experiments-modal__chart']}
             />
           </div>
+
+          {/* Stats for Nerds Section - moved to bottom */}
+          {hasEnoughData && (
+            <ChartSection
+              title="Stats for Nerds"
+              className={styles['experiments-modal__section']}
+            >
+              <div className={styles['experiments-modal__stats']}>
+                <p className={styles['experiments-modal__stat']}>
+                  A two-proportion Z-Test resulted in a one-tailed p-value of{' '}
+                  <span className={
+                    statsData.pValue !== 'N/A' && !isNaN(statsData.pValue) && parseFloat(statsData.pValue) >= 0.10
+                      ? styles['experiments-modal__stat-value--red']
+                      : styles['experiments-modal__stat-value--green']
+                  }>
+                    {statsData.pValue}
+                  </span>
+                </p>
+                <p className={styles['experiments-modal__stat']}>
+                  90% Confidence Interval for Master:{' '}
+                  <span className={styles['experiments-modal__stat-value']}>
+                    {statsData.masterConfidenceInterval}
+                  </span>
+                </p>
+                <p className={styles['experiments-modal__stat']}>
+                  90% Confidence Interval for Variant:{' '}
+                  <span className={styles['experiments-modal__stat-value']}>
+                    {statsData.variantConfidenceInterval}
+                  </span>
+                </p>
+              </div>
+            </ChartSection>
+          )}
 
           {/* Only show divider and action button if experiment is active */}
           {experimentStatus === 'Active' && (


### PR DESCRIPTION
## Summary
Automated resolution of Jira ticket CKYE-4.

## Jira Ticket  
[CKYE-4](https://ckye.atlassian.net/browse/CKYE-4): Reorder the "Stats for Nerds" card in the experiments results modal

## Description
Stats for nerds is not needed for the majority of users and should move to the bottom of the Experiments modal, underneath the speedometer gauges. An example of the new and updated UI can be found here: https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Cyke-Web-App?node-id=213-4440&m=dev  

## Changes Made
- Moved the "Stats for Nerds" section from between Results and Potential Impact sections to the bottom of the modal
- Now appears after the speedometer gauge cards (Master and Variant variants)
- Only displays when sufficient data is available (200+ total MRs)
- Maintains all existing functionality and styling

## Testing
- ✅ Lint checks passed
- ✅ Production build successful