### PR TITLE
[CKYE-3] Update rounding values for Experiments statistical results

### DIFF
--- a/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
+++ b/src/components/organisms/ExperimentsModal/ExperimentsModal.jsx
@@ -70,8 +70,8 @@ const ExperimentsModal = ({
     const z = (betterP - worseP) / se;
     const pValue = 1 - jStat.normal.cdf(z, 0, 1);
 
-    // Format as decimal with up to 10 decimal places, removing trailing zeros
-    return pValue.toFixed(10).replace(/\.?0+$/, '');
+    // Format as decimal with up to 2 decimal places (hundredths)
+    return pValue.toFixed(2);
   };
 
   const calculateIntervals = (successes, total) => {
@@ -92,9 +92,9 @@ const ExperimentsModal = ({
     lower = Math.max(0, Math.min(1, lower));
     upper = Math.max(0, Math.min(1, upper));
 
-    // Convert to percentage and format to 2 decimal places
-    const lowerPercent = (lower * 100).toFixed(2);
-    const upperPercent = (upper * 100).toFixed(2);
+    // Convert to percentage and format to 1 decimal place (tenths)
+    const lowerPercent = (lower * 100).toFixed(1);
+    const upperPercent = (upper * 100).toFixed(1);
 
     return `${lowerPercent}% – ${upperPercent}%`;
   }
@@ -126,7 +126,7 @@ const ExperimentsModal = ({
     let confidenceLevel = 0;
     const pVal = statsData.pValue;
     if (pVal !== 'N/A' && !isNaN(pVal)) {
-      confidenceLevel = ((1 - pVal) * 100).toFixed(2);
+      confidenceLevel = ((1 - pVal) * 100).toFixed(1);
     }
 
     // Determine the winner and create appropriate description


### PR DESCRIPTION
## Summary
Automated resolution of Jira ticket CKYE-3.

## Jira Ticket  
[CKYE-3](https://ckye.atlassian.net/browse/CKYE-3): Update rounding values for Experiments > statistical results

## Description
The ticket requested updating the rounding precision for various statistical values displayed in the experiments modal:
- Confidence level percentages should round to tenths (e.g., 68.1% instead of 68.08%)
- P-values should round to hundredths (e.g., 0.32 instead of 0.3192034291)

## Changes Made
- Updated confidence level display from 2 decimal places to 1 decimal place (tenths)
- Updated p-value display from 10 decimal places to 2 decimal places (hundredths)
- Updated confidence intervals from 2 decimal places to 1 decimal place for consistency
- All percentage values now display with appropriate precision as specified

## Testing
- ✅ Lint checks passed
- ✅ Code changes are minimal and focused on formatting only