### PR TITLE
[CKYE-5] Web app's BG needs to be updated to darker black

### DIFF
--- a/src/components/organisms/MarkdownEditor/MarkdownEditor.module.scss
+++ b/src/components/organisms/MarkdownEditor/MarkdownEditor.module.scss
@@ -2,7 +2,7 @@
 @import '../../../styles/mixins';
 
 .markdown-editor {
-  background-color: $background-dark;
+  background-color: $black-bg-extra-dark;
   border-radius: 8px;
   height: 100%;
   overflow: hidden;
@@ -13,7 +13,7 @@
   // Override MDXEditor styles to match our theme
   :global {
     .mdxeditor {
-      background-color: $background-dark;
+      background-color: $black-bg-extra-dark;
       color: $white-primary;
       font-family: inherit;
       height: 100%;
@@ -22,7 +22,7 @@
 
       // Toolbar styling
       .mdxeditor-toolbar {
-        background-color: $black-bg-light;
+        background-color: $black-bg-dark;
         border-bottom: 1px solid $border-color;
         padding: 8px 16px;
         gap: 8px;
@@ -80,7 +80,7 @@
       .mdxeditor-root-contenteditable {
         padding: 24px;
         color: $white-primary;
-        background-color: $background-dark;
+        background-color: $black-bg-extra-dark;
         overflow-y: auto;
         flex: 1;
         min-height: 0;
@@ -124,7 +124,7 @@
         }
 
         code {
-          background-color: $black-bg-light;
+          background-color: $black-bg-dark;
           color: $code-red;
           padding: 2px 4px;
           border-radius: 3px;
@@ -138,7 +138,7 @@
         }
 
         pre {
-          background-color: $black-bg-light;
+          background-color: $black-bg-dark;
           border: 1px solid $border-color;
           border-radius: 4px;
           padding: 16px;
@@ -181,7 +181,7 @@
           }
 
           th {
-            background-color: $black-bg-light;
+            background-color: $black-bg-dark;
             font-weight: 600;
           }
 
@@ -199,10 +199,10 @@
 
       // CodeMirror styling
       .cm-editor {
-        background-color: $black-bg-light;
+        background-color: $black-bg-dark;
 
         .cm-gutters {
-          background-color: $black-bg-light;
+          background-color: $black-bg-dark;
           border-right: 1px solid $border-color;
           color: $white-secondary;
         }
@@ -223,7 +223,7 @@
         color: $white-primary;
 
         input {
-          background-color: $black-bg-light;
+          background-color: $black-bg-dark;
           border: 1px solid $border-color;
           color: $white-primary;
           padding: 8px;

--- a/src/components/pages/TwoColumnPage/TwoColumnPage.module.scss
+++ b/src/components/pages/TwoColumnPage/TwoColumnPage.module.scss
@@ -25,7 +25,7 @@
   &__right {
     flex: 1;
     overflow-x: auto;
-    background-color: $background-dark;
+    background-color: $black-bg-extra-dark;
     padding: 40px;
     overflow-y: scroll;
     max-height: 100vh;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -9,6 +9,7 @@ $white-secondary: #9B9B9B;    // White/Secondary - Secondary text color for defa
 
 // Background Colors
 $black: #000000;              // Pure black - Used for overlays and modal backdrops
+$black-bg-extra-dark: #191919; // Black/BG Extra Dark - Darker background for right column
 $black-bg-light: #202020;     // Black/BG Light - Main background color
 $black-bg-dark: #252525;      // Black/BG Dark - Modal/dropdown background color
 $black-light: #353535;        // Black/Light - Selected item background


### PR DESCRIPTION
## Summary
Automated resolution of Jira ticket CKYE-5.

## Jira Ticket
[CKYE-5](https://ckye.atlassian.net/browse/CKYE-5): Web app's BG needs to be updated to darker black

## Description
`TwoColumnPage_two-column-page__right__1jpRt` is currently too light of a share of black. Right column bg should be changed to BG Extra Dark #191919 

The embedded MD editor should also be skinned to match this new darker background

## Changes Made
- Added new `$black-bg-extra-dark` (#191919) variable to `_variables.scss`
- Updated TwoColumnPage right column background to use the new darker color
- Updated MarkdownEditor styles to match the darker theme:
  - Toolbar background changed from `$black-bg-light` to `$black-bg-dark`
  - Code blocks and pre elements updated to use `$black-bg-dark`
  - Editor content area uses the new `$black-bg-extra-dark`
  - CodeMirror editor theme updated to match

## Testing
- ✅ Lint checks passed
- ✅ All tests passed
- ✅ Production build successful

🤖 Generated with [Claude Code](https://claude.ai/code)