### PR TITLE
CKYE-15: Update Speedometer chart stats styling

### DIFF
--- a/src/components/organisms/VariantCard/VariantCard.module.scss
+++ b/src/components/organisms/VariantCard/VariantCard.module.scss
@@ -51,11 +51,11 @@
 
   &__current-value {
     font-family: $font-family-primary;
-    font-size: 28px;
+    font-size: 14px;
     font-weight: $font-weight-bold;
     line-height: 1;
     letter-spacing: 0.2px;
-    color: $code-blue;
+    color: $white-secondary;
   }
 
   &__total-value {


### PR DESCRIPTION
## Summary
- Updated the Speedometer component (VariantCard) chart stats styling to match the updated Figma design
- Changed font size from 28px to 14px and color from blue to secondary gray (#9B9B9B)
- All stats now use consistent Overpass Bold 14 (D5 style) typography

## Changes Made
- Modified `src/components/organisms/VariantCard/VariantCard.module.scss`
  - Updated `&__current-value` font-size: 28px → 14px
  - Updated `&__current-value` color: $code-blue → $white-secondary (#9B9B9B)
  - Ensured both current and total values use the same styling

## Testing
- ✅ Lint check passed
- ✅ Build completed successfully
- ✅ Visual verification against Figma design

## Related
- **Jira Ticket**: [CKYE-15](https://ckye.atlassian.net/browse/CKYE-15)
- **Figma Design**: [Speedometer Component](https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Cyke-Web-App?node-id=213-5348&t=OsO35bG1Z5fsmnQE-4)

## Before & After
**Before**: Current value displayed in larger font (28px) with blue color
**After**: Current value matches total value styling (14px, gray color)

🤖 Generated with [Claude Code](https://claude.ai/code)