### PR TITLE
CKYE-14: Update field styles and padding

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.module.scss
+++ b/src/components/atoms/Dropdown/Dropdown.module.scss
@@ -11,7 +11,7 @@
   &__label {
     @include body-medium;
     @include font-semibold;
-    color: $white-secondary;
+    color: $white-primary;
     display: block;
   }
   

--- a/src/components/atoms/TextField/TextField.module.scss
+++ b/src/components/atoms/TextField/TextField.module.scss
@@ -10,7 +10,7 @@
   &__label {
     @include body-medium;
     @include font-semibold;
-    color: $white-secondary;
+    color: $white-primary;
     display: block;
   }
   

--- a/src/components/molecules/WorkspaceSelector/WorkspaceSelector.module.scss
+++ b/src/components/molecules/WorkspaceSelector/WorkspaceSelector.module.scss
@@ -8,7 +8,7 @@
   &__label {
     @include body-medium;
     @include font-semibold;
-    color: $text-secondary;
+    color: $white-primary;
     display: block;
     margin-bottom: 8px;
   }

--- a/src/components/organisms/AddUserModal/AddUserModal.module.scss
+++ b/src/components/organisms/AddUserModal/AddUserModal.module.scss
@@ -50,7 +50,7 @@
   &__form {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 24px;
     padding: 12px 0;
   }
 

--- a/src/components/organisms/AddWorkspaceModal/AddWorkspaceModal.module.scss
+++ b/src/components/organisms/AddWorkspaceModal/AddWorkspaceModal.module.scss
@@ -50,7 +50,7 @@
   &__form {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 24px;
     padding: 12px 0;
   }
 

--- a/src/components/organisms/CreateExperimentModal/CreateExperimentModal.module.scss
+++ b/src/components/organisms/CreateExperimentModal/CreateExperimentModal.module.scss
@@ -80,7 +80,7 @@
   &__body {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 24px;
     padding: 12px 0;
   }
 


### PR DESCRIPTION
## Summary
- Updated all form field label colors for increased contrast and readability
- Increased modal form field spacing from 12px to 24px
- Applied consistent styling across all form components

## Changes Made

### Label Color Updates (Secondary → Primary)
- `TextField` component: Label color changed from #9B9B9B to #D5D5D5
- `Dropdown` component: Label color changed from #9B9B9B to #D5D5D5
- `WorkspaceSelector` component: Label color changed from #9B9B9B to #D5D5D5

### Modal Form Spacing Updates (12px → 24px)
- `AddUserModal`: Form field gap increased to 24px
- `AddWorkspaceModal`: Form field gap increased to 24px
- `CreateExperimentModal`: Body field gap increased to 24px

## Testing
- ✅ Lint check passed
- ✅ Build completed successfully
- ✅ Visual verification against Figma design

## Related
- **Jira Ticket**: [CKYE-14](https://ckye.atlassian.net/browse/CKYE-14)
- **Figma Design**: [Field Styles](https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Cyke-Web-App?node-id=51-2495&t=86K8GNJ3mmaP94cy-4)

## Impact
These changes improve visual hierarchy and accessibility by:
- Increasing contrast for field labels (better readability)
- Providing more breathing room between form fields (easier to scan)
- Creating consistent styling across all form components

🤖 Generated with [Claude Code](https://claude.ai/code)