### PR TITLE
refactor: use lib/api pattern for workspace fetching

### DIFF
--- a/src/app/admin/workspaces/[id]/page.jsx
+++ b/src/app/admin/workspaces/[id]/page.jsx
@@ -2,27 +2,10 @@ import { authOptions } from '@/lib/auth';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
+import { getWorkspace } from '@/lib/api/workspaces';
 import TwoColumnPage from '@/components/pages/TwoColumnPage/TwoColumnPage';
 import Sidebar from '@/components/templates/Sidebar/Sidebar';
 import WorkspaceDetailsClient from './WorkspaceDetailsClient';
-
-async function getWorkspace(id, cookieHeader) {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-  const response = await fetch(`${baseUrl}/api/workspaces/${id}`, {
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      'Cookie': cookieHeader,
-    }
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch workspace');
-  }
-
-  const data = await response.json();
-  return data.data;
-}
 
 export default async function WorkspaceDetailsPage({ params }) {
   const session = await getServerSession(authOptions);
@@ -37,7 +20,8 @@ export default async function WorkspaceDetailsPage({ params }) {
 
   let workspace;
   try {
-    workspace = await getWorkspace(params.id, cookieHeader);
+    const response = await getWorkspace(params.id, cookieHeader);
+    workspace = response.data;
   } catch (error) {
     console.error('Error fetching workspace:', error);
     redirect('/admin/workspaces');

--- a/src/lib/api/workspaces.js
+++ b/src/lib/api/workspaces.js
@@ -26,8 +26,36 @@ export async function getWorkspaces(cookieHeader = null) {
   }
 }
 
+export async function getWorkspace(id, cookieHeader = null) {
+  try {
+    // Use absolute URL for server-side requests
+    const url = typeof window === 'undefined' 
+      ? `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/workspaces/${id}`
+      : `/api/workspaces/${id}`;
+      
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookieHeader && { Cookie: cookieHeader }), // Forward cookies if provided
+      },
+      credentials: 'same-origin', // Include cookies for client-side requests
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to fetch workspace');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching workspace:', error);
+    throw error;
+  }
+}
+
 export async function createWorkspace(workspaceData, cookieHeader = null) {
-  console.log('j', workspaceData)
   try {
     // Use absolute URL for server-side requests
     const url = typeof window === 'undefined' 


### PR DESCRIPTION
- Add getWorkspace function to lib/api/workspaces
- Update page.jsx to use lib/api instead of direct fetch
- Maintain consistent API patterns across codebase