### PR TITLE
fix: remove gap from VariantCard stats container (CKYE-17)

### DIFF
--- a/src/components/organisms/VariantCard/VariantCard.module.scss
+++ b/src/components/organisms/VariantCard/VariantCard.module.scss
@@ -46,7 +46,6 @@
   &__stats-container {
     display: flex;
     align-items: baseline;
-    gap: 8px;
   }
 
   &__current-value {


### PR DESCRIPTION
## Summary
- Removed 8px gap from `.variant-card__stats-container` class
- Stats container elements now display with no gap between them

## JIRA Ticket
[CKYE-17](https://ckye.atlassian.net/browse/CKYE-17)

## Changes Made
- Updated `VariantCard.module.scss` to remove `gap: 8px` property from `&__stats-container`

## Testing
- Verified the styling change is applied correctly
- No gap appears between stats container elements

Page ID: cme78g7a700018ovg8p0ijuv0

🤖 Generated with [Claude Code](https://claude.ai/code)