### PR TITLE
fix: remove icons from AddUserModal CTA buttons (CKYE-18)

### DIFF
--- a/src/components/organisms/AddUserModal/AddUserModal.jsx
+++ b/src/components/organisms/AddUserModal/AddUserModal.jsx
@@ -78,6 +78,7 @@ const AddUserModal = ({ closeModal, workspaces = [], addUsers, workspace = null 
               variant="primary"
               onClick={closeModal}
               className={styles['add-user-modal__button']}
+              icon={null}
             >
               Cancel
             </Button>
@@ -85,6 +86,7 @@ const AddUserModal = ({ closeModal, workspaces = [], addUsers, workspace = null 
               variant="secondary"
               onClick={handleInviteMembers}
               className={styles['add-user-modal__button']}
+              icon={null}
             >
               Invite Members
             </Button>


### PR DESCRIPTION
## Summary
- Removed icons from Cancel and Invite Members buttons in AddUserModal
- Added `icon={null}` prop to prevent default icon from appearing

## JIRA Ticket
[CKYE-18](https://ckye.atlassian.net/browse/CKYE-18)

## Problem
The CTA buttons in the AddUserModal were displaying icons due to the Button component having a default icon prop value of `/settings.svg`.

## Solution
Explicitly set `icon={null}` on both CTA buttons to prevent icons from appearing.

## Testing
- Verified that Cancel and Invite Members buttons no longer display icons
- Modal functionality remains unchanged

Page ID: cme78g7a700018ovg8p0ijuv0

🤖 Generated with [Claude Code](https://claude.ai/code)