### PR TITLE
fix: remove grey border from workspace details tabs (CKYE-21)

### DIFF
--- a/src/app/admin/workspaces/[id]/WorkspaceDetailsClient.module.scss
+++ b/src/app/admin/workspaces/[id]/WorkspaceDetailsClient.module.scss
@@ -19,7 +19,6 @@
   &__tabs {
     display: flex;
     gap: 32px;
-    border-bottom: 1px solid $black-light;
     margin-bottom: 32px;
   }
 


### PR DESCRIPTION
## Summary
- Removed the grey border-bottom from the workspace details tabs container
- Active tab still maintains the blue underline indicator
- Aligns the design with Figma specifications

## JIRA Ticket
[CKYE-21](https://ckye.atlassian.net/browse/CKYE-21)

## Problem
There was a full-width grey line/border at the top of the workspace details page (under the tabs) that shouldn't be there according to the Figma design.

## Solution
Removed `border-bottom: 1px solid $black-light;` from the `&__tabs` styling while keeping the blue underline on the active tab.

## Figma Reference
https://www.figma.com/design/1wJBV3eb9vlRvuxQICmBwY/Ckye-Web-App?node-id=563-10276&m=dev

Page ID: cme78g7a700018ovg8p0ijuv0

🤖 Generated with [Claude Code](https://claude.ai/code)